### PR TITLE
Fixing url problem with ckan cloud storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 .pyre/
 
 src/ckanext-tester/
+src/ckanext-iauthfunctions

--- a/src/ckan/ckan/logic/action/create.py
+++ b/src/ckan/ckan/logic/action/create.py
@@ -2,6 +2,7 @@
 
 '''API functions for adding data to CKAN.'''
 
+from importlib import resources
 import logging
 import random
 import re
@@ -312,7 +313,6 @@ def resource_create(context, data_dict):
             data_dict['size'] = upload.filesize
 
     pkg_dict['resources'].append(data_dict)
-
     try:
         context['defer_commit'] = True
         context['use_cache'] = False
@@ -334,7 +334,6 @@ def resource_create(context, data_dict):
     #  Run package show again to get out actual last_resource
     updated_pkg_dict = _get_action('package_show')(context, {'id': package_id})
     resource = updated_pkg_dict['resources'][-1]
-
     #  Add the default views to the new resource
     logic.get_action('resource_create_default_resource_views')(
         {'model': context['model'],
@@ -347,7 +346,9 @@ def resource_create(context, data_dict):
 
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_create(context, resource)
-
+    # mohab
+    mohab_resource_name = resource['name']
+    resource['url'] = f'https://storage.cloud.google.com/mohabtester/{mohab_resource_name}'
     return resource
 
 

--- a/src/ckan/ckan/views/resource.py
+++ b/src/ckan/ckan/views/resource.py
@@ -94,7 +94,9 @@ def read(package_type, id, resource_id):
             break
     if not resource:
         return base.abort(404, _(u'Resource not found'))
-
+    # mohab acted here
+    mohab_resource_name = resource['name']
+    resource['url'] = f'https://storage.cloud.google.com/mohabtester/{mohab_resource_name}'
     # get package license info
     license_id = package.get(u'license_id')
     try:


### PR DESCRIPTION
the url wasn't showing well, although this is a fix, it's temporary until we create our own upload plugin, it's a hack more than a fix that included changing Ckan resource (read function - see where i commented #mohab acted here), and create.py (although this is not required. see where i put #mohab name).